### PR TITLE
add contentapp template

### DIFF
--- a/ItemTemplates/ContentApp/.template.config/template.json
+++ b/ItemTemplates/ContentApp/.template.config/template.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "UmbracoPackageTeam",
+    "classifications": [
+        "Web",
+        "Umbraco",
+        "v8"
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    },
+
+    "identity": "Umbraco.Templates.Items.ContentApp",
+    "groupIdentity": "Umbraco.Templates.Items.ContentApp",
+
+    "name": "Umbraco Content App Item",
+    "shortName": "umbraco-v8-contentapp",
+    "description": "Umbraco content app files",
+    
+    "sourceName": "UmbracoPackage.1"
+}

--- a/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/Lang/en.xml
+++ b/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/Lang/en.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+	<area alias="UmbracoPackage.1">
+		<key alias="contentAppHeader">UmbracoPackage.1 super content app</key>
+		<key alias="contentAppDesc">My super awesome content app</key>
+	</area>
+</language>

--- a/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js
+++ b/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js
@@ -1,0 +1,32 @@
+/**
+ * @ngdoc
+ * 
+ * @name: contentAppController
+ * @description: code for a content app in the umbraco back office
+ * 
+ */
+(function () {
+    'use strict';
+
+    function contentAppController() {
+
+        var vm = this;
+        vm.loading = true;
+        vm.message = "";
+
+        function init() {
+            getInfo();
+        }
+
+        function getInfo() {
+            vm.message = "Content App init() has run";
+            vm.loading = false;
+        }
+
+        // call init, when controller is loaded 
+        init(); 
+    }
+
+    angular.module('umbraco')
+        .controller('umbracopackage__1ContentAppController', contentAppController);
+})();

--- a/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html
+++ b/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html
@@ -1,0 +1,17 @@
+<div ng-controller="umbracopackage__1ContentAppController as vm">
+
+    <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
+    <div ng-if="!vm.loading">
+        <umb-box>
+            <umb-box-header title-key="UmbracoPackage.1_contentAppHeader"
+                            description-key="UmbracoPackage.1_contentAppDesc">
+            </umb-box-header>
+            <umb-box-content>
+                <h4>{{vm.message}}</h4>
+            </umb-box-content>
+
+        </umb-box>
+    </div>
+
+</div>

--- a/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/package.manifest
+++ b/ItemTemplates/ContentApp/App_Plugins/UmbracoPackage.1/ContentApp/package.manifest
@@ -1,0 +1,14 @@
+{
+    "javascript": [
+    "~/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js"
+  ],
+  "contentApps": [
+    {
+        "name": "My App", // required - the name that appears under the icon
+        "alias": "umbracopackage._1-contentapp", // required - unique alias for your app
+        "weight": 0, // optional, default is 0, use values between -99 and +99 to appear between the existing Content (-100) and Info (100) apps
+        "icon": "icon-cupcake", // required - the icon to use
+        "view": "~/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html" // required - the location of the view file
+    }
+  ]
+}

--- a/ProjectTemplates/UmbracoPackage.1/.template.config/template.json
+++ b/ProjectTemplates/UmbracoPackage.1/.template.config/template.json
@@ -60,9 +60,16 @@
           ]
         },
         {
-          "condition": "(!propertyEditory)",
+          "condition": "(!contentApp)",
           "exclude": [
-            "**/property/**"
+            "**/[Cc]ontent[Aa]pp/**/*",
+            "**/[Cc]ontent[Aa]pp*.cs"
+          ]
+        },
+        {
+          "condition": "(!propertyEditor)",
+          "exclude": [
+            "**/[Pp]roperty[Ee]ditor/**"
           ]
         }
       ]
@@ -95,12 +102,19 @@
       "defaultValue": "false",
       "description": "Include template code for a dashboard"
     },
+    "contentApp" : 
+    {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Include template code for a content app"
+    },
     "propertyEditor" :
     {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "description": "Include template code for a property Type Editor"
+      "description": "Include template code for a property Type Editor (not yet implemented)"
     },
     "github" :
     {

--- a/ProjectTemplates/UmbracoPackage.1/src/UmbracoPackage.1/App_Plugins/UmbracoPackage.1/ContentApp/Lang/en.xml
+++ b/ProjectTemplates/UmbracoPackage.1/src/UmbracoPackage.1/App_Plugins/UmbracoPackage.1/ContentApp/Lang/en.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+	<area alias="UmbracoPackage.1">
+		<key alias="contentAppHeader">UmbracoPackage.1 super content app</key>
+		<key alias="contentAppDesc">My super awesome content app</key>
+	</area>
+</language>

--- a/ProjectTemplates/UmbracoPackage.1/src/UmbracoPackage.1/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js
+++ b/ProjectTemplates/UmbracoPackage.1/src/UmbracoPackage.1/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js
@@ -1,0 +1,32 @@
+/**
+ * @ngdoc
+ * 
+ * @name: contentAppController
+ * @description: code for a content app in the umbraco back office
+ * 
+ */
+(function () {
+    'use strict';
+
+    function contentAppController() {
+
+        var vm = this;
+        vm.loading = true;
+        vm.message = "";
+
+        function init() {
+            getInfo();
+        }
+
+        function getInfo() {
+            vm.message = "Content App init() has run";
+            vm.loading = false;
+        }
+
+        // call init, when controller is loaded 
+        init(); 
+    }
+
+    angular.module('umbraco')
+        .controller('umbracopackage__1ContentAppController', contentAppController);
+})();

--- a/ProjectTemplates/UmbracoPackage.1/src/UmbracoPackage.1/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html
+++ b/ProjectTemplates/UmbracoPackage.1/src/UmbracoPackage.1/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html
@@ -1,0 +1,17 @@
+<div ng-controller="umbracopackage__1ContentAppController as vm">
+
+    <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
+    <div ng-if="!vm.loading">
+        <umb-box>
+            <umb-box-header title-key="UmbracoPackage.1_contentAppHeader"
+                            description-key="UmbracoPackage.1_contentAppDesc">
+            </umb-box-header>
+            <umb-box-content>
+                <h4>{{vm.message}}</h4>
+            </umb-box-content>
+
+        </umb-box>
+    </div>
+
+</div>

--- a/ProjectTemplates/UmbracoPackage.1/src/UmbracoPackage.1/App_Plugins/UmbracoPackage.1/ContentApp/package.manifest
+++ b/ProjectTemplates/UmbracoPackage.1/src/UmbracoPackage.1/App_Plugins/UmbracoPackage.1/ContentApp/package.manifest
@@ -1,0 +1,14 @@
+{
+    "javascript": [
+    "~/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.controller.js"
+  ],
+  "contentApps": [
+    {
+        "name": "My App", // required - the name that appears under the icon
+        "alias": "umbracopackage._1-contentapp", // required - unique alias for your app
+        "weight": 0, // optional, default is 0, use values between -99 and +99 to appear between the existing Content (-100) and Info (100) apps
+        "icon": "icon-cupcake", // required - the icon to use
+        "view": "~/App_Plugins/UmbracoPackage.1/ContentApp/contentapp.html" // required - the location of the view file
+    }
+  ]
+}


### PR DESCRIPTION
Adds a basic Content App to the UmbracoPackage project template using 'c' switch:

```dotnet new umbraco-v8-package -n MyName -c```

And as a new Item template:

```dotnet new umbraco-v8-contentapp -n MyName```

Draft PR as need to check:
- why I didn't need 'primaryOutputs' defined in template.json
- how the copying of source files in created projects should work
- whose file name / casing conventions we should be following