### PR TITLE
Add github actions umbpack push step

### DIFF
--- a/ItemTemplates/github-build/.github/workflows/build.yml
+++ b/ItemTemplates/github-build/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
       # path to your package.xml file should go here.
       - name: Create Umbraco package file
         run: UmbPack pack ./package.xml -o ${{ env.OUTPUT }} -v ${{ steps.get_version.outputs.VERSION }}
+
+#        For the push step to work you will need to create an api key on Our, and save it as a secret on Github with the name "UMBRACO_DEPLOY_KEY"
+#      - name: Push package to Our
+#        run: umbpack push ${{ env.OUTPUT }}/UmbracoPackage.1_${{ steps.get_version.outputs.VERSION }}.zip -k ${{ secrets.UMBRACO_DEPLOY_KEY }}
         
       - name: upload-artifacts
         uses: actions/upload-artifact@v2

--- a/ItemTemplates/github-build/.github/workflows/build.yml
+++ b/ItemTemplates/github-build/.github/workflows/build.yml
@@ -49,12 +49,16 @@ jobs:
       
       - name: Create NuGet package file
         run: dotnet pack ${{ env.LIBRARY_FOLDER }} -c ${{ env.CONFIG }} --no-build --include-symbols -o ${{ env.OUTPUT }} /p:version=${{ steps.get_version.outputs.VERSION }} 
+
+#      # For the push step to work you will need to create an api key on NuGet, and save it as a secret on Github with the name "NUGET_DEPLOY_KEY"
+#      - name: Push package to NuGet
+#        run: dotnet nuget push ${{ env.OUTPUT }}/*.nupkg -k ${{ secrets.NUGET_DEPLOY_KEY } -s https://api.nuget.org/v3/index.json
         
       # path to your package.xml file should go here.
       - name: Create Umbraco package file
         run: UmbPack pack ./package.xml -o ${{ env.OUTPUT }} -v ${{ steps.get_version.outputs.VERSION }}
 
-#        For the push step to work you will need to create an api key on Our, and save it as a secret on Github with the name "UMBRACO_DEPLOY_KEY"
+#      # For the push step to work you will need to create an api key on Our, and save it as a secret on Github with the name "UMBRACO_DEPLOY_KEY"
 #      - name: Push package to Our
 #        run: umbpack push ${{ env.OUTPUT }}/UmbracoPackage.1_${{ steps.get_version.outputs.VERSION }}.zip -k ${{ secrets.UMBRACO_DEPLOY_KEY }}
         

--- a/ProjectTemplates/UmbracoPackage.1/.github/workflows/build.yml
+++ b/ProjectTemplates/UmbracoPackage.1/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
       # path to your package.xml file should go here.
       - name: Create Umbraco package file
         run: UmbPack pack ./package.xml -o ${{ env.OUTPUT }} -v ${{ steps.get_version.outputs.VERSION }}
+
+#        For the push step to work you will need to create an api key on Our, and save it as a secret on Github with the name "UMBRACO_DEPLOY_KEY"
+#      - name: Push package to Our
+#        run: umbpack push ${{ env.OUTPUT }}/UmbracoPackage.1_${{ steps.get_version.outputs.VERSION }}.zip -k ${{ secrets.UMBRACO_DEPLOY_KEY }}
         
       - name: upload-artifacts
         uses: actions/upload-artifact@v2

--- a/ProjectTemplates/UmbracoPackage.1/.github/workflows/build.yml
+++ b/ProjectTemplates/UmbracoPackage.1/.github/workflows/build.yml
@@ -49,12 +49,16 @@ jobs:
       
       - name: Create NuGet package file
         run: dotnet pack ${{ env.LIBRARY_FOLDER }} -c ${{ env.CONFIG }} --no-build --include-symbols -o ${{ env.OUTPUT }} /p:version=${{ steps.get_version.outputs.VERSION }} 
+
+#      # For the push step to work you will need to create an api key on NuGet, and save it as a secret on Github with the name "NUGET_DEPLOY_KEY"
+#      - name: Push package to NuGet
+#        run: dotnet nuget push ${{ env.OUTPUT }}/*.nupkg -k ${{ secrets.NUGET_DEPLOY_KEY } -s https://api.nuget.org/v3/index.json
         
       # path to your package.xml file should go here.
       - name: Create Umbraco package file
         run: UmbPack pack ./package.xml -o ${{ env.OUTPUT }} -v ${{ steps.get_version.outputs.VERSION }}
 
-#        For the push step to work you will need to create an api key on Our, and save it as a secret on Github with the name "UMBRACO_DEPLOY_KEY"
+#      # For the push step to work you will need to create an api key on Our, and save it as a secret on Github with the name "UMBRACO_DEPLOY_KEY"
 #      - name: Push package to Our
 #        run: umbpack push ${{ env.OUTPUT }}/UmbracoPackage.1_${{ steps.get_version.outputs.VERSION }}.zip -k ${{ secrets.UMBRACO_DEPLOY_KEY }}
         


### PR DESCRIPTION
Seems a bit weird we don't have a push step in the github actions, but I guess it may be because it won't work unless specifically configured with a key unlike the other steps.

Figured it may be nice to have a boilerplate though? This works #onmymachine, and when testing this update locally it did a proper replace of the `UmbracoPackage.1` part in the middle of the push command as well 🎉