### PR TITLE
Add pre-requisite to working with and installing templates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,8 @@
 # Project Templates
 
+## Pre-requisite
+You must be using Visual Studio 2019 else you are likely to have Roslyn issues.
+
 ## 1. Create a new Umbraco Package
 
 A new blank project for building an umbraco package

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,10 @@ This repository contains some templates for starting new Umbraco package project
 
 The templates can be used via the `dotnet new` command. 
 
+## Pre-requisite
+You must be using Visual Studio 2019 to work with these templates.
+
+
 ## Installation 
 You can install all the templates from a NuGet package
 


### PR DESCRIPTION
Working with these templates (both creating new and using them) must be done in VS2019 or newer.
Added pre-requisite to docs to indicate this.