### PR TITLE
Add umbbox tab

### DIFF
--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/example.section.controller.js
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/example.section.controller.js
@@ -34,6 +34,12 @@
                     'alias': 'tabs',
                     'icon': 'icon-tab color-green',
                     'view': Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath + '/uiexamples/tabs/tabs.html',
+                },
+                {
+                    'name': 'umbbox',
+                    'alias': 'umbbox',
+                    'icon': 'icon-box',
+                    'view': Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath + '/uiexamples/umbbox/umbbox.html'
                 }
             ]
         }

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/lang/en.xml
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/lang/en.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+	<area alias="umbbox">
+		<key alias="boxTitle">The umb-box element</key>
+		<key alias="boxDescription">The umb-box element is used as a wrapper for boxes in Umbraco. It contains a header and content element that are described below in more detail.</key>
+		<key alias="headerTitle">The umb-box-header element</key>
+		<key alias="headerDescription">
+			<![CDATA[
+			<p>The umb-box-header element is the top part of a box, above the horizontal line. It can contain a title and description or their language keys.</p>
+			<h2>Adding a button</h2>
+			<p>Anything inside the umb-box-header element will be right aligned, just like the "API Documentation" button at the top of this current box. See the example below:</p>
+			]]>			
+		</key>
+		<key alias="headerButtonNote">The vm.linkAway method is a method in the angular controller, not a standard Umbraco thing. It calls window.open(url) on the passed in url.</key>
+		<key alias="contentTitle">The umb-box-content element</key>
+		<key alias="contentDescription">The umb-box-content element is anything within the box and under the header. It is a simple wrapper for whatever you wish to put inside, and comes with no special config options.</key>
+	</area>
+</language>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/package.manifest
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/package.manifest
@@ -1,0 +1,3 @@
+﻿{
+  "javascript": [ "~/app_plugins/uiexamples/umbbox/umbbox.controller.js" ]
+}

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/umbbox.controller.js
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/umbbox.controller.js
@@ -1,0 +1,12 @@
+﻿
+(function () {
+    'use strict';
+
+    function umbbox($scope, exampleResource) {
+        var vm = this;
+        vm.linkAway = exampleResource.linkAway;
+    };
+
+    angular.module('umbraco')
+        .controller('umbboxController', umbbox);
+})();

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/umbbox.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/umbbox.html
@@ -1,0 +1,80 @@
+﻿<div ng-controller="umbboxController as vm">
+
+    <umb-box id="group-umb-box">
+        <umb-box-header title-key="umbbox_boxTitle">
+            <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBox');"
+                        label-key="example_apiDocumentation"
+                        type="button"
+                        button-style="info">
+            </umb-button>
+        </umb-box-header>
+
+        <umb-box-content>
+            <umb-code-snippet language="'html'">
+&lt;umb-box&gt;
+    &lt;umb-box-header title="this is a title"&gt;&lt;/umb-box-header&gt;
+    &lt;umb-box-content&gt;
+        // Content here
+    &lt;/umb-box-content&gt;
+&lt;/umb-box&gt;
+            </umb-code-snippet>
+
+            <localize key="umbbox_boxDescription"></localize>
+        </umb-box-content>
+    </umb-box>
+
+    <umb-box id="group-umb-box-header">
+        <umb-box-header title-key="umbbox_headerTitle">
+            <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBoxHeader');"
+                        label-key="example_apiDocumentation"
+                        type="button"
+                        button-style="info">
+            </umb-button>
+        </umb-box-header>
+
+        <umb-box-content>
+            <umb-code-snippet language="'html'">
+&lt;umb-box-header
+    [title="{string}"]
+    [title-key="{string}"]
+    [description="{string}"]
+    [description-key="{string}"]&gt;
+&lt;/umb-box-header&gt;
+            </umb-code-snippet>
+
+            <localize key="umbbox_headerDescription"></localize>
+
+            <umb-code-snippet language="'html'">
+&lt;umb-box-header title-key="umbbox_headerTitle"&gt;
+    &lt;umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBoxHeader');"
+                label-key="example_apiDocumentation"
+                type="button"
+                button-style="info"&gt;
+    &lt;/umb-button&gt;
+&lt;/umb-box-header&gt;
+            </umb-code-snippet>
+
+            <localize key="umbbox_headerButtonNote"></localize>
+        </umb-box-content>
+    </umb-box>
+
+    <umb-box id="group-umb-box-content">
+        <umb-box-header title-key="umbbox_contentTitle">
+            <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBoxContent');"
+                        label-key="example_apiDocumentation"
+                        type="button"
+                        button-style="info">
+            </umb-button>
+        </umb-box-header>
+
+        <umb-box-content>
+            <umb-code-snippet language="'html'">
+&lt;umb-box-content&gt;
+&lt;/umb-box-content&gt;
+            </umb-code-snippet>
+
+            <localize key="umbbox_contentDescription"></localize>
+        </umb-box-content>
+    </umb-box>
+
+</div>


### PR DESCRIPTION
This PR adds a new tab with umbbox examples, it covers:

- [x] Umb-box
- [x] Buttons on right
- [x] Header
- [x] Content
- [ ] Footer 
- [ ] Collapse

Are we sure the footer is even a thing? A search for `umb-box-footer` in the source code returned no results.

As for the collapse, is that just adding a button and ng-click to toggle it to show and hide? Or is there more to it? Any examples of implementation would be nice, but doesn't look like something that exists out of the box..

Looks like this on my machine:

![image](https://user-images.githubusercontent.com/36075913/99771252-17dd2100-2b09-11eb-8104-2dc2862b4edf.png)


