### PR TITLE
add package pipeline

### DIFF
--- a/.github/workflows/ui-examples.yml
+++ b/.github/workflows/ui-examples.yml
@@ -1,0 +1,62 @@
+# Builds a library, and packages it up.
+#
+# Works on a release/version tag
+#   e.g release/1.0.2 will build v1.0.2
+#
+
+name: Build and Package
+
+env:
+  OUTPUT: ./Output
+  LIBRARY_FOLDER: ./src/UmbracoPackage.1
+  CONFIG: release
+
+on:
+  push:
+    tags:
+      - "uiexamples/*"
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:      
+      - name: Get Version 
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/uiexamples\//}
+        shell: bash
+      
+      - name: checkout
+        uses: actions/checkout@v2
+        
+      - name: Setup NuGet.exe for use with actions
+        uses: NuGet/setup-nuget@v1.0.2        
+        
+      - name: Setup .net core
+        uses: actions/setup-dotnet@v1.4.0
+      
+      - name: Setup UmbPack
+        run: dotnet tool install Umbraco.Tools.Packages --global
+        
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Restore Packages
+        run: dotnet restore ./src
+
+      - name: Build Project
+        run: msbuild ./src -p:Configuration=${{ env.CONFIG }}
+        
+      # path to your package.xml file should go here.
+      - name: Create Umbraco package file
+        run: UmbPack pack ./package.xml -o ${{ env.OUTPUT }} -v ${{ steps.get_version.outputs.VERSION }}
+
+#      # For the push step to work you will need to create an api key on Our, and save it as a secret on Github with the name "UMBRACO_DEPLOY_KEY"
+#      - name: Push package to Our
+#        run: umbpack push ${{ env.OUTPUT }}/UmbracoPackage.1_${{ steps.get_version.outputs.VERSION }}.zip -k ${{ secrets.UMBRACO_DEPLOY_KEY }}
+        
+      - name: upload-artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Build-Results-${{ steps.get_version.outputs.VERSION }}
+          path: ${{ env.OUTPUT }}/**/*

--- a/.github/workflows/ui-examples.yml
+++ b/.github/workflows/ui-examples.yml
@@ -31,7 +31,8 @@ jobs:
         
       - name: Setup NuGet.exe for use with actions
         uses: NuGet/setup-nuget@v1
-        with: nuget-version: ${{ matrix.nuget }}  
+        with: 
+          nuget-version: ${{ matrix.nuget }}  
         
       - name: Setup .net core
         uses: actions/setup-dotnet@v1.4.0

--- a/.github/workflows/ui-examples.yml
+++ b/.github/workflows/ui-examples.yml
@@ -40,15 +40,6 @@ jobs:
       - name: Setup UmbPack
         run: dotnet tool install Umbraco.Tools.Packages --global
         
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
-
-      - name: Restore Packages
-        run: dotnet restore ./src
-
-      - name: Build Project
-        run: msbuild ./src -p:Configuration=${{ env.CONFIG }}
-        
       # path to your package.xml file should go here.
       - name: Create Umbraco package file
         run: UmbPack pack ./package.xml -o ${{ env.OUTPUT }} -v ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/ui-examples.yml
+++ b/.github/workflows/ui-examples.yml
@@ -4,7 +4,7 @@
 #   e.g release/1.0.2 will build v1.0.2
 #
 
-name: Build and Package
+name: Pack UI Examples
 
 env:
   OUTPUT: ./Output
@@ -30,7 +30,8 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Setup NuGet.exe for use with actions
-        uses: NuGet/setup-nuget@v1.0.2        
+        uses: NuGet/setup-nuget@v1
+        with: nuget-version: ${{ matrix.nuget }}  
         
       - name: Setup .net core
         uses: actions/setup-dotnet@v1.4.0

--- a/.github/workflows/ui-examples.yml
+++ b/.github/workflows/ui-examples.yml
@@ -8,8 +8,6 @@ name: Pack UI Examples
 
 env:
   OUTPUT: ./Output
-  LIBRARY_FOLDER: ./src/UmbracoPackage.1
-  CONFIG: release
 
 on:
   push:

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<umbPackage>
+  <info>
+    <package>
+      <name>UI Examples</name>
+      <version>1.0.0</version>
+      <iconUrl></iconUrl>
+      <licence url="https://opensource.org/licenses/MIT">MIT</licence>
+      <url>https://our.umbraco.com</url>
+      <requirements type="strict">
+        <major>8</major>
+        <minor>0</minor>
+        <patch>0</patch>
+      </requirements>
+    </package>
+    <author>
+      <name>UmbracoPackageTeam</name>
+      <website>https://our.umbraco.com</website>
+    </author>
+    <readme><![CDATA[Collection of UI examples for the Umbraco Backoffice. They are all installed into a new section and are self-documented.]]></readme>
+  </info>
+  <files>
+    <folder path="ItemTemplates/UIExamples/App_Plugins/uiexamples" orgPath="app_plugins/uiexamples" />
+  </files>
+  <Actions />
+  <control />
+  <DocumentTypes />
+  <Templates />
+  <Stylesheets />
+  <Macros />
+  <DictionaryItems />
+  <Languages />
+  <DataTypes />
+</umbPackage>


### PR DESCRIPTION
In the current implementation this PR will add a package pipeline that uses umbpack to create an Umbraco ZIP whenever we push a tag - `"uiexamples/*"`.
Currently doesn't push the package anywhere but saves it as an artifact at the end.
Here is a build output from my fork test: https://github.com/jmayntzhusen/Package.Templates/actions/runs/381034120 

