### PR TITLE
UI Examples review

### DIFF
--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/default.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/default.html
@@ -1,11 +1,11 @@
 ﻿<div>
     <umb-box>
-        <umb-box-header title-key="uiexamples_heading"
-                        description-key="uiexamples_description"></umb-box-header>
+        <umb-box-header title-key="default_heading"
+                        description-key="default_description"></umb-box-header>
 
         <umb-box-content>
 
-            <localize key="uiexamples_intro"></localize>
+            <localize key="default_intro"></localize>
 
         </umb-box-content>
     </umb-box>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/example.css
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/example.css
@@ -20,3 +20,17 @@
     .uiexamples-outline-no-margin > div {
         border: 1px solid blue;
     }
+
+.uiexamples-umbbox-outline {
+    border: 1px solid red;
+}
+    
+    .uiexamples-umbbox-outline > .header {
+        border: 1px solid blue;
+        margin: 5px;
+    }
+
+    .uiexamples-umbbox-outline > .content {
+        border: 1px solid green;
+        margin: 5px;
+    }

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/example.section.controller.js
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/example.section.controller.js
@@ -24,25 +24,25 @@
                     'view': Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath + '/uiexamples/icons/icons.html',
                 },
                 {
-                    'name': 'simple',
+                    'name': 'Simple',
                     'alias': 'simple',
                     'icon': 'icon-checkbox-empty',
                     'view': Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath + '/uiexamples/Simple/simple.html',
                 },
                 {
-                    'name': 'tabs',
+                    'name': 'Tabs',
                     'alias': 'tabs',
                     'icon': 'icon-tab',
                     'view': Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath + '/uiexamples/tabs/tabs.html',
                 },
                 {
-                    'name': 'umbbox',
+                    'name': 'Umbbox',
                     'alias': 'umbbox',
                     'icon': 'icon-box',
                     'view': Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath + '/uiexamples/umbbox/umbbox.html'
                 },
                 {
-                    'name': 'layout',
+                    'name': 'Layout',
                     'alias': 'layout',
                     'icon': 'icon-layout',
                     'view': Umbraco.Sys.ServerVariables.umbracoSettings.appPluginsPath + '/uiexamples/layout/layout.html'

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/icons/icons.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/icons/icons.html
@@ -6,6 +6,7 @@
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbIcon');"
                         label-key="example_apiDocumentation"
                         type="button"
+                        icon="icon-book"
                         button-style="info">
             </umb-button>
         </umb-box-header>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/icons/package.manifest
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/icons/package.manifest
@@ -2,6 +2,5 @@
   "javascript": [
     "~/App_Plugins/uiexamples/icons/icons.controller.js",
     "~/App_Plugins/uiexamples/icons/iconoverlay.controller.js"
-
   ]
 }

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/lang/en.xml
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/lang/en.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
 	<area alias="example">
-		<key alias="apiDocumentation">API Documentation</key>
+		<key alias="apiDocumentation">API Documentation</key>		
+	</area>
+	<area alias="sections">
+		<key alias="uiExamples">UIExamples</key>		
+	</area>
+	<area alias="default">
+		<key alias="heading">UI Examples</key>
+		<key alias="description">A backoffice component library as a package</key>
+		<key alias="intro">
+			<![CDATA[			
+			<p>This package is developed and maintained by the Umbraco Package Team.</p>
+			<p>It contains a quick overview of several backoffice elements and shows you how to use them. The package is also great reference material, if you see something within this section that isn't covered on one of the tabs you can go to your App_Plugins folder and check the source.</p>
+			<p>Everything in this package is frontend only (except for a bit of code that automatically adds this section to all user groups).</p>
+			]]>
+		</key>
 	</area>
 </language>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/layout/lang/en.xml
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/layout/lang/en.xml
@@ -4,21 +4,27 @@
 
 		<!-- loading -->
 		<key alias="loadingTitle">Loading indicator</key>
-		<key alias="loadingDescription">Display loading bubbles why things setup</key>
-		<key alias="loadingMessage"><![CDATA[<p>The umbraco load indicator, allows you to show the three progress 'bubbles' while your page initializes or you do work that will take some time</p>]]></key>
+		<key alias="loadingDescription">Display a loading indicator while things setup</key>
+		<key alias="loadingMessage">
+			<![CDATA[<p>The umbraco load indicator allows you to show the three progress 'bubbles' while your page initializes or you do work that will take some time.</p>
+			<p>Click the button below for an example, or try it yourself using this sample code:</p>
+		]]>
+		</key>
+		<key alias="loading">Start loading</key>
+		<key alias="stopLoading">Stop loading</key>
 
 		<!-- layout (flex) -->
 		<key alias="layoutTitle">Layout</key>
-		<key alias="layoutDescription">classes to aid page layout</key>
+		<key alias="layoutDescription">Classes to aid page layout</key>
 		
 		<key alias="flex">
 				<![CDATA[
-			<p>Umbraco conatins many helper methods for controlling how a flex box and its child items are rendered.</p>
-			<p>for a complete rundown of flexbox behaviour see <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/" target="_blank">a guide to flexbox</a></p>
+			<p>Umbraco contains many helper methods for controlling how a flexbox and its child items are rendered.</p>
+			<p>For a complete rundown of flexbox behaviour see <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/" target="_blank">a guide to flexbox</a>.</p>
 		]]></key>
-		<key alias="flexJustify">Jusfiy content within a flex layout - good for spacing your content across the page</key>
-		<key alias="flexItems">Align items within the flex layout, good for aligning text and image boxes of diffrent sizes</key>
-		<key alias="flexContent">Align content within flex layout, good for controlling how boxes flow across the page</key>
+		<key alias="flexJustify">Jusfiy content within a flex layout - good for spacing your content across the page.</key>
+		<key alias="flexItems">Align items within the flex layout, good for aligning text and image boxes of different sizes.</key>
+		<key alias="flexContent">Align content within a flex layout, good for controlling how boxes flow across the page.</key>
 
 		
 		<!-- margins -->

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/layout/layout.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/layout/layout.html
@@ -40,7 +40,7 @@
 
                 <localize key="layout_flexJustify"></localize>
 
-                <umb-code-snippet language="'html'">&lt;div class="flex jusitfy-center"&gt;&lt;/div&gt;</umb-code-snippet>
+                <umb-code-snippet language="'html'">&lt;div class="flex justify-center"&gt;&lt;/div&gt;</umb-code-snippet>
 
                 <div class="flex justify-between">
 

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/layout/package.manifest
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/layout/package.manifest
@@ -1,4 +1,3 @@
 {
-  "javascript": [ "~/app_plugins/uiexamples/layout/layout.controller.js" ],
-  "css": [ "~/app_plugins/uiexamples/layout/layout.css" ]
+  "javascript": [ "~/app_plugins/uiexamples/layout/layout.controller.js" ]
 }

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/package.manifest
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/package.manifest
@@ -3,10 +3,11 @@
     "~/app_plugins/uiexamples/example.section.controller.js",
     "~/app_plugins/uiexamples/example.resource.js"
   ],
+  "css": [ "~/app_plugins/uiexamples/example.css" ],
   "sections": [
     {
       "alias": "uiExamples",
-      "name": "UI Examples"
+      "name": "UI Examples",
     }
   ],
   "dashboards": [

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/simple/lang/en.xml
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/simple/lang/en.xml
@@ -3,13 +3,16 @@
   <area alias="example">
     <key alias="buttonTitle">umb-button</key>
     <key alias="buttonDescription">Render a styled button</key>
-    <key alias="buttonNote"></key>
+    <key alias="buttonNote">
+		<![CDATA[
+            This is an example of using a button. The type of button depends on the "button-style", you can see the options in the example above and see them rendered down below.
+        ]]>
+	</key>
     <key alias="groupedButtonTitle">umb-grouped-button</key>
     <key alias="groupedButtonDescription">Render a grouped button</key>
-    <key alias="groupedButtonNote"></key>
+    <key alias="groupedButtonNote">This is an example of a button group, you can see a few examples rendered down below.</key>
     <key alias="groupedButton_default">Grouped style 'info'</key>
     <key alias="groupedButton_subButtonA">Sub Button A</key>
     <key alias="groupedButton_subButtonB">Sub Button B</key>
-    <key alias="groupedButtonNote"></key>
   </area>
 </language>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/simple/lang/en.xml
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/simple/lang/en.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
-  <area alias="example">
+  <area alias="simple">
     <key alias="buttonTitle">umb-button</key>
     <key alias="buttonDescription">Render a styled button</key>
     <key alias="buttonNote">

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/simple/simple.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/simple/simple.html
@@ -1,9 +1,9 @@
 ﻿<div ng-controller="exampleSectionSimpleController as vm">
     <umb-box>
-        <umb-box-header title-key="example_buttonTitle"
-                        description-key="example_buttonDescription">
+        <umb-box-header title-key="simple_buttonTitle"
+                        description-key="simple_buttonDescription">
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbButton');"
-                        label-key="example_apiDocumentation"
+                        label-key="simple_apiDocumentation"
                         type="button"
                         icon="icon-book"
                         button-style="info">
@@ -17,7 +17,7 @@
     type="button"
     button-style="block | action | primary | info | success | warning | danger | inverse | link"&gt;
 &lt;/umb-button&gt;</umb-code-snippet>
-            <localize key="example_buttonNote"></localize>
+            <localize key="simple_buttonNote"></localize>
         </umb-box-content>
 
         <umb-box-content>
@@ -74,10 +74,10 @@
     </umb-box>
 
     <umb-box>
-        <umb-box-header title-key="example_groupedButtonTitle"
-                        description-key="example_groupedButtonDescription">
+        <umb-box-header title-key="simple_groupedButtonTitle"
+                        description-key="simple_groupedButtonDescription">
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbButtonGroup');"
-                        label-key="example_apiDocumentation"
+                        label-key="simple_apiDocumentation"
                         type="button"
                         icon="icon-book"
                         button-style="info">
@@ -91,7 +91,7 @@
     sub-buttons="vm.buttonGroup.subButtons"
     direction="up | down">
 &lt;/umb-button-group&gt;</umb-code-snippet>
-            <localize key="example_groupedButtonNote"></localize>
+            <localize key="simple_groupedButtonNote"></localize>
         </umb-box-content>
 
         <umb-box-content>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/simple/simple.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/simple/simple.html
@@ -5,6 +5,7 @@
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbButton');"
                         label-key="example_apiDocumentation"
                         type="button"
+                        icon="icon-book"
                         button-style="info">
             </umb-button>
         </umb-box-header>
@@ -78,6 +79,7 @@
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbButtonGroup');"
                         label-key="example_apiDocumentation"
                         type="button"
+                        icon="icon-book"
                         button-style="info">
             </umb-button>
         </umb-box-header>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/tabs/lang/en.xml
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/tabs/lang/en.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
-	<area alias="example">
+	<area alias="tabs">
 		<key alias="tabsTitle">Tabs</key>
     <key alias="tabsDescription">This shows how you can use tabs</key>
     <key alias="tabsNavDocumentation">API Documentation umbTabsNav</key>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/tabs/tabs.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/tabs/tabs.html
@@ -5,11 +5,13 @@
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbTabsNav');"
                         label-key="example_tabsNavDocumentation"
                         type="button"
+                        icon="icon-book"
                         button-style="info">
             </umb-button>
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbTabContent');"
                         label-key="example_tabContentDocumentation"
                         type="button"
+                        icon="icon-book"
                         button-style="info">
             </umb-button>
         </umb-box-header>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/tabs/tabs.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/tabs/tabs.html
@@ -1,15 +1,15 @@
 ﻿<div ng-controller="tabsController as vm">
 
     <umb-box>
-        <umb-box-header title-key="example_tabsTitle" description-key="example_tabsDescription">
+        <umb-box-header title-key="tabs_tabsTitle" description-key="tabs_tabsDescription">
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbTabsNav');"
-                        label-key="example_tabsNavDocumentation"
+                        label-key="tabs_tabsNavDocumentation"
                         type="button"
                         icon="icon-book"
                         button-style="info">
             </umb-button>
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbTabContent');"
-                        label-key="example_tabContentDocumentation"
+                        label-key="tabs_tabContentDocumentation"
                         type="button"
                         icon="icon-book"
                         button-style="info">

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/lang/en.xml
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/lang/en.xml
@@ -2,17 +2,21 @@
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
 	<area alias="umbbox">
 		<key alias="boxTitle">The umb-box element</key>
-		<key alias="boxDescription">The umb-box element (outlined in red) is used as a wrapper for boxes in Umbraco. It contains a header (outlined in blue) and content element (outlined in green) that are described below in more detail.</key>
+		<key alias="boxDescription">
+			<![CDATA[
+			<p>The <span style="color:red";>umb-box</span> element (outlined in red) is used as a wrapper for boxes in Umbraco. It contains a <span style="color:blue";>header</span> (outlined in blue) and <span style="color:green";>content</span> element (outlined in green) that are described below in more detail.
+			]]>
+		</key>
 		<key alias="headerTitle">The umb-box-header element</key>
 		<key alias="headerDescription">
 			<![CDATA[
-			<p>The umb-box-header element is the top part of a box, above the horizontal line. It can contain a title and description or their language keys. The umb-box-header is outlined in red above.</p>
+			<p>The umb-box-header element is the top part of a box, above the horizontal line. It can contain a title and description or their language keys.</p>
 			<h4>Adding a button</h2>
 			<p>Anything inside the umb-box-header element will be right aligned, just like the "API Documentation" button at the top of this current box. See the example below:</p>
 			]]>			
 		</key>
 		<key alias="headerButtonNote">The vm.linkAway method is a method in the angular controller, not a standard Umbraco thing. It calls window.open(url) on the passed in url.</key>
 		<key alias="contentTitle">The umb-box-content element</key>
-		<key alias="contentDescription">The umb-box-content element is anything within the box and under the header, it is outlined in red in this box. It is a simple wrapper for whatever you wish to put inside, and comes with no special config options.</key>
+		<key alias="contentDescription">The umb-box-content element is anything within the box and under the header. It is a simple wrapper for whatever you wish to put inside, and comes with no special config options.</key>
 	</area>
 </language>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/lang/en.xml
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/lang/en.xml
@@ -2,17 +2,17 @@
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
 	<area alias="umbbox">
 		<key alias="boxTitle">The umb-box element</key>
-		<key alias="boxDescription">The umb-box element is used as a wrapper for boxes in Umbraco. It contains a header and content element that are described below in more detail.</key>
+		<key alias="boxDescription">The umb-box element (outlined in red) is used as a wrapper for boxes in Umbraco. It contains a header (outlined in blue) and content element (outlined in green) that are described below in more detail.</key>
 		<key alias="headerTitle">The umb-box-header element</key>
 		<key alias="headerDescription">
 			<![CDATA[
-			<p>The umb-box-header element is the top part of a box, above the horizontal line. It can contain a title and description or their language keys.</p>
-			<h2>Adding a button</h2>
+			<p>The umb-box-header element is the top part of a box, above the horizontal line. It can contain a title and description or their language keys. The umb-box-header is outlined in red above.</p>
+			<h4>Adding a button</h2>
 			<p>Anything inside the umb-box-header element will be right aligned, just like the "API Documentation" button at the top of this current box. See the example below:</p>
 			]]>			
 		</key>
 		<key alias="headerButtonNote">The vm.linkAway method is a method in the angular controller, not a standard Umbraco thing. It calls window.open(url) on the passed in url.</key>
 		<key alias="contentTitle">The umb-box-content element</key>
-		<key alias="contentDescription">The umb-box-content element is anything within the box and under the header. It is a simple wrapper for whatever you wish to put inside, and comes with no special config options.</key>
+		<key alias="contentDescription">The umb-box-content element is anything within the box and under the header, it is outlined in red in this box. It is a simple wrapper for whatever you wish to put inside, and comes with no special config options.</key>
 	</area>
 </language>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/umbbox.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/umbbox.html
@@ -5,6 +5,7 @@
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBox');"
                         label-key="example_apiDocumentation"
                         type="button"
+                        icon="icon-book"
                         button-style="info">
             </umb-button>
         </umb-box-header>
@@ -28,6 +29,7 @@
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBoxHeader');"
                         label-key="example_apiDocumentation"
                         type="button"
+                        icon="icon-book"
                         button-style="info">
             </umb-button>
         </umb-box-header>
@@ -63,6 +65,7 @@
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBoxContent');"
                         label-key="example_apiDocumentation"
                         type="button"
+                        icon="icon-book"
                         button-style="info">
             </umb-button>
         </umb-box-header>

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/umbbox.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/umbbox/umbbox.html
@@ -1,7 +1,7 @@
 ﻿<div ng-controller="umbboxController as vm">
 
-    <umb-box id="group-umb-box">
-        <umb-box-header title-key="umbbox_boxTitle">
+    <umb-box id="group-umb-box" class="uiexamples-umbbox-outline">
+        <umb-box-header title-key="umbbox_boxTitle" class="header">
             <umb-button action="vm.linkAway('https://our.umbraco.com/apidocs/v8/ui/#/api/umbraco.directives.directive:umbBox');"
                         label-key="example_apiDocumentation"
                         type="button"
@@ -10,7 +10,7 @@
             </umb-button>
         </umb-box-header>
 
-        <umb-box-content>
+        <umb-box-content class="content">
             <umb-code-snippet language="'html'">
 &lt;umb-box&gt;
     &lt;umb-box-header title="this is a title"&gt;&lt;/umb-box-header&gt;


### PR DESCRIPTION
Ran through the current UI Examples package and did the following:

- Added missing localization content and updated some for clarity
- Ensured a similar style, naming and case throughout the tabs
- Moved the custom css from the layout folder into a general one that can be shared (very little css so feels silly to have several different ones? The css used is for illustrations not necessary for the examples to work for others)
- Enhanced the umbbox example a bit with border colors shamelessly stolen from the layout example 😊