### PR TITLE
changes for the Icons to load pre and post Umb v8.8

### DIFF
--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/icons/icons.controller.js
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/icons/icons.controller.js
@@ -4,36 +4,30 @@
     function exampleSectionIconsController(exampleResource, iconHelper, overlayService) {
 
         var vm = this;
+        vm.loading = true;
         vm.linkAway = exampleResource.linkAway;
 
         vm.openIconOverlay = openIconOverlay;
 
         function init() {
 
-            var allIconMethod = iconHelper.getAllIcons;
-            if (allIconMethod === undefined) {
-                // pre v8.8 method is getIcons 
-                allIconMethod = iconHelper.getIcons;
+            if (iconHelper.getAllIcons !== undefined) {
+
+                iconHelper.getAllIcons().then(function (icons) {
+                    vm.icons = icons;
+                    vm.loading = false;
+                });
             }
-
-            allIconMethod().then(function (icons) {
-
-                vm.icons = icons;
-
-                if (icons && icons.length > 0) {
-                    var legacyIcons = icons.filter(function (icon) {
-                        return !vm.icons.find(function (x) {
-                            return x.name == icon;
-                        });
-                    }).map(function (icon) {
+            else {
+                iconHelper.getIcons().then(function (icons) {
+                    vm.icons = icons.map(function (icon) {
                         return {
-                            name: icon,
-                            svgString: null
+                            name: icon, svgString: null
                         };
                     });
-                    vm.icons = legacyIcons.concat(vm.icons);
-                }
-            });
+                    vm.loading = false;
+                });
+            }
         }
 
         /////////

--- a/ItemTemplates/UIExamples/App_Plugins/uiexamples/icons/icons.html
+++ b/ItemTemplates/UIExamples/App_Plugins/uiexamples/icons/icons.html
@@ -27,6 +27,8 @@
         </umb-box-content>
     </umb-box>
 
+    <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
+
     <umb-box>
 
         <umb-box-header title-key="uiexamplesIcons_listTitle"


### PR DESCRIPTION
Fixes that hopefully sort of the loading of the icons between Umbraco versions. 

pre v8.8 the getIcons method returns the names  post getAllIcons returns the objects. 

Calling them via another variable (setting the variable to the method) seems to cause issues withthe this calls within the umbraco methods. I am no JS expert - so just revert to two calls.